### PR TITLE
Updated race array filter constants to match backend naming convention

### DIFF
--- a/src/pages/selection/candidates/index.jsx
+++ b/src/pages/selection/candidates/index.jsx
@@ -218,12 +218,12 @@ class Candidates extends Component {
         break
       case 'race-parkboardcommissioner': 
         this.setState({
-          races: this.state.filteredRaces.filter((race) => race.positionName === "Park Board commissioner")
+          races: this.state.filteredRaces.filter((race) => race.positionName === "Park Board Commissioner")
         })
         break
       case 'race-schooltrustee':
         this.setState({
-          races: this.state.filteredRaces.filter((race) => race.positionName === "School trustee")
+          races: this.state.filteredRaces.filter((race) => race.positionName === "School Trustee")
         })
         break
       case 'race-vicepresident': 


### PR DESCRIPTION
One of recent back-end changes included the renaming of strings representing different race types.
I've matched the front-end filter to match those naming conventions.